### PR TITLE
Build container for dependencies.R

### DIFF
--- a/.github/workflows/dependencies-container.yml
+++ b/.github/workflows/dependencies-container.yml
@@ -1,0 +1,50 @@
+name: Create and publish a R environment Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: hdr-bgnn/minnow-traits-r-env
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Update R environment container when Scripts/dependencies.R changes
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v25
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M')"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image when Scripts/dependencies.R changes
+        if: contains(steps.changed-files.outputs.modified_files, 'Scripts/dependencies.R')
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.date.outputs.date }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/rocker-org/r-ver:4.2.1
+ADD Scripts /src/Minnow_Traits/Scripts
+RUN Rscript /src/Minnow_Traits/Scripts/dependencies.R

--- a/Scripts/dependencies.R
+++ b/Scripts/dependencies.R
@@ -35,3 +35,4 @@ devtools::install_version("moments", version = "0.14.1")
 devtools::install_version("ggplot2", version = "3.3.5")
 devtools::install_version("RColorBrewer", version = "1.1.2")
 devtools::install_version("ggpubr", version = "0.4.0")
+


### PR DESCRIPTION
Adds a github action to build a `hdr-bgnn/minnow-traits-r-env` container based on `Scripts/dependencies.R` when this file changes in the main branch. When this file changes on the main branch a new container will be created with the current date/time.

The container created will follow this pattern:
```
ghcr.io/hdr-bgnn/minnow-traits-r-env:<year>-<month>-<day>-<hour>-<minute>
```

A blank line was added to the end of Scripts/dependencies.R so an initial container will be build when this commit is merged.