### PR TITLE
Use new Fish-AIR data

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ See the [official instructions for installing snakemake](https://snakemake.readt
 To install snakemake on the OSC cluster run:
 ```
 module load miniconda3
-conda create -n snakemake -c bioconda -c conda-forge snakemake -y
+conda create -n snakemake -c bioconda -c conda-forge -c r snakemake r-essentials r-xml -y
 ```
 
 where -n designates the name, "snakemake", -c designates the channel(s), "bioconda" and "conda-forge".

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ module load miniconda3
 conda create -n snakemake -c bioconda -c conda-forge -c r snakemake r-essentials r-xml -y
 ```
 
-where -n designates the name, "snakemake", -c designates the channel(s), "bioconda" and "conda-forge".
+where `-n` designates the name, "snakemake", and `-c` designates the channel(s): "bioconda", "conda-forge", and "r".
 
 To check that the environment was made:
 ```

--- a/Scripts/Data_Manipulation.R
+++ b/Scripts/Data_Manipulation.R
@@ -69,10 +69,9 @@ heatmap_sd_blob_path <- dfs$Heatmap_SD_Blob_Image
 mm.df <- merge(iqm.df, meta.df, by="ARKID", all.x = TRUE)
 
 #how many rows have empty iqm fields? using "quality" to test
-nrow(mm.df) #42423
+nrow(mm.df) #20720
 nrow(mm.df %>% 
-       tidyr::drop_na(quality)) #20719
-#difference: 21704 without IQM data
+       tidyr::drop_na(quality)) #20720
 
 ## burress previous measurements
 # measurements from Burress et al. 2017 (see PDFs/Burress et al. 2017  Ecological diversification associated with the benthic‐to‐pelagic transition supinfo.docx)

--- a/Scripts/Data_Manipulation.R
+++ b/Scripts/Data_Manipulation.R
@@ -1,21 +1,53 @@
 # set paths for files
 # Meghan Balk
 # balk@battelleecology.org
+source("Scripts/fish-air.R")
 
 #### read yaml file ----
 dfs <- yaml::read_yaml(file = config_file)
 checkpoint.limit_image <- dfs$limit_images
 
-meta.df <- read.csv(file = dfs$Image_Metadata)
+meta.df.term_to_colname <- list(
+  "https://fishair.org/terms/ARKID" = "ARKID",
+  "http://rs.tdwg.org/ac/terms/accessURI" = "accessURI",
+  "http://rs.tdwg.org/dwc/terms/scientificName" = "scientificName",
+  "http://rs.tdwg.org/dwc/terms/genus" = "genus",
+  "http://rs.tdwg.org/dwc/terms/family" = "family",
+  "http://rs.tdwg.org/dwc/terms/ownerInstitutionCode" = "imageOwnerInstitutionCode"
+)
+meta.df <- fa_read_csv(
+  csv_path = dfs$Image_Metadata,
+  meta_xml_path = dfs$File_Metadata,
+  term_to_colname = meta.df.term_to_colname)
 
-iqm.df <- read.csv(file = dfs$Image_Quality_Metadata)
-
-multi.df <- read.csv(file = dfs$Multimedia)
+iqm.df.term_to_colname <- list(
+  "https://fishair.org/terms/ARKID" = "ARKID",
+  "https://fishair.org/terms/quality"="quality",
+  "https://fishair.org/terms/specimenView" = "specimenView",
+  "https://fishair.org/terms/specimenCurved" = "specimenCurved",
+  "https://fishair.org/terms/brightness" = "brightness",
+  "https://fishair.org/terms/colorIssue" = "colorIssue",
+  "https://fishair.org/terms/containsScaleBar" = "containsScaleBar", # formerly contains_ruler
+  "https://fishair.org/terms/partsOverlapping" = "partsOverlapping",
+  "https://fishair.org/terms/onFocus" = "onFocus",
+  "https://fishair.org/terms/partsMissing" = "partsMissing",
+  "https://fishair.org/terms/allPartsVisible" = "allPartsVisible",
+  "https://fishair.org/terms/partsFolded" = "partsFolded",
+  "https://fishair.org/terms/uniformBackground" = "uniformBackground",
+  "http://rs.tdwg.org/dwc/terms/ownerInstitutionCode" = "ownerInstitutionCode",
+  "https://fishair.org/terms/specimenQuantity" = "specimenQuantity"
+)
+iqm.df <- fa_read_csv(
+  csv_path = dfs$Image_Quality_Metadata,
+  meta_xml_path = dfs$File_Metadata,
+  term_to_colname = iqm.df.term_to_colname)
 
 b.df <- read.csv(file = dfs$Burress)
 
 # Output file paths
+
 burress_minnow_filtered_path <- dfs$Burress_Minnow_Filtered
+minnow_filtered_path <- dfs$Minnow_Filtered
 sampling_path <- dfs$Sampling
 presence_absence_matrix_path <- dfs$Presence_Absence_Matrix
 sampling_species_burress_path <- dfs$Sampling_Species_Burress
@@ -29,33 +61,18 @@ heatmap_sd_blob_path <- dfs$Heatmap_SD_Blob_Image
 #### manipulate data ----
 
 ## metadata image files
-# downloaded from https://bgnn.tulane.edu/hdrweb/hdr/imagemetadata/
-# meta is metadata about the images
+# downloaded from https://fishair.org/
+# meta is metadata about the image files
 # iqm is metadata about image quality
-# multi is metadata about the multimedia files
 
-# will combine all the files to one metadata file for ease of use
-meta.iqm <- dplyr::left_join(meta.df, iqm.df,
-                             by = "arkID",
-                             suffix = c("", ".iqm"))
-meta.multi <- dplyr::left_join(meta.iqm, multi.df,
-                               by = "arkID",
-                               suffix = c("", ".multi"))
-mm1 <- meta.multi %>% 
-  dplyr::mutate(fileNameAsDelivered = ifelse(is.na(fileNameAsDelivered), fileNameAsDelivered.multi, fileNameAsDelivered))
-mm.df <- mm1 %>% 
-  dplyr::select(-fileNameAsDelivered.multi)
+# Merge iqm.df and meta.df into a merged dataset
+mm.df <- merge(iqm.df, meta.df, by="ARKID", all.x = TRUE)
 
 #how many rows have empty iqm fields? using "quality" to test
 nrow(mm.df) #42423
 nrow(mm.df %>% 
        tidyr::drop_na(quality)) #20719
 #difference: 21704 without IQM data
-
-# remove ".jpg" from file name to more easily align with file name in presence.df
-mm.df$fileNameAsDelivered <- gsub(meta.df$fileNameAsDelivered,
-                                  pattern = ".jpg",
-                                  replacement = "")
 
 ## burress previous measurements
 # measurements from Burress et al. 2017 (see PDFs/Burress et al. 2017  Ecological diversification associated with the benthic‐to‐pelagic transition supinfo.docx)

--- a/Scripts/Minnow_Selection_Image_Quality_Metadata.R
+++ b/Scripts/Minnow_Selection_Image_Quality_Metadata.R
@@ -79,9 +79,9 @@ sampling.df$Burress_et_al._2017_Overlap_Images_sp[2] <- paste0(length(unique(min
 
 sampling.df$Selection_Criteria[3] <- "Only INHS or UWZM (none from UWZM)"
 
-institutions <- c("Illinois Natural History Survey - Fish (ILLS-F)", 
-                  "University of Wisconsin-Madison Zoological Museum - Fish (UWZM-F)")
-images.minnows.trim <- minnow.keep[minnow.keep$ownerInstitutionCode.multi %in% institutions,]
+institutions <- c("INHS)", 
+                  "UWZM")
+images.minnows.trim <- minnow.keep[minnow.keep$imageOwnerInstitutionCode %in% institutions,]
 
 unique(images.minnows.trim$ownerInstitutionCode.multi)
 nrow(images.minnows.trim)
@@ -113,8 +113,7 @@ sampling.df$Selection_Criteria[4] <- "No empty URLs"
 #test with a known url
 ##http://www.tubri.org/HDR/INHS/INHS_FISH_65294.jpg
 ##INHS_FISH_33814.jpg
-test <- images.minnows.trim[images.minnows.trim$fileNameAsDelivered == "INHS_FISH_33814" |
-                            images.minnows.trim$accessURI == "https://bgnn.tulane.edu/hdr-share/ftp/ark/89609/GLIN/INHS/bg976724.jpg",]
+test <- images.minnows.trim[images.minnows.trim$ARKID == "0040g17t",]
 empty <- c()
 for(i in 1:nrow(test)){
   if(!isTRUE(valid_url(test$accessURI[i]))){

--- a/Scripts/Minnow_Selection_Image_Quality_Metadata.R
+++ b/Scripts/Minnow_Selection_Image_Quality_Metadata.R
@@ -16,7 +16,7 @@ source("Scripts/init.R")
 c.names <- c("Selection_Criteria",
              "All_Minnows_Images_sp",
              "Burress_et_al._2017_Overlap_Images_sp")
-sampling.df = data.frame(matrix(nrow = 15, ncol = length(c.names)))
+sampling.df = data.frame(matrix(nrow = 7, ncol = length(c.names)))
 colnames(sampling.df) = c.names
 
 #### 1. sampling of the metadata ----
@@ -24,20 +24,20 @@ colnames(sampling.df) = c.names
 #how many species and images in image metadata (mm.df)?
 sampling.df$Selection_Criteria[1] <- "Metadata files"
 
-length(unique(mm.df$arkID))
-length(unique(mm.df$scientificName))
+nrow(mm.df) #20720
+length(unique(mm.df$scientificName)) #188
 
-sampling.df$All_Minnows_Images_sp[1] <- paste0(length(unique(mm.df$arkID)),
+sampling.df$All_Minnows_Images_sp[1] <- paste0(nrow(mm.df),
                                                " (",
                                                length(unique(mm.df$scientificName)),
                                                ")")
 
 #now reduce to Burress et al. 2017
 
-length(unique(mm.df$arkID[mm.df$scientificName %in% b.sp]))
-length(unique(mm.df$scientificName[mm.df$scientificName %in% b.sp]))
+nrow(mm.df[mm.df$scientificName %in% b.sp,]) #2818
+length(unique(mm.df$scientificName[mm.df$scientificName %in% b.sp])) #22
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[1] <- paste0(length(unique(mm.df$arkID[mm.df$scientificName %in% b.sp])),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[1] <- paste0(nrow(mm.df[mm.df$scientificName %in% b.sp,]),
                                                                " (",
                                                                length(unique(mm.df$scientificName[mm.df$scientificName %in% b.sp])),
                                                                ")")
@@ -46,7 +46,7 @@ sampling.df$Burress_et_al._2017_Overlap_Images_sp[1] <- paste0(length(unique(mm.
 
 sampling.df$Selection_Criteria[2] <- "Image Quality Metadata Selection"
 
-minnow.keep <- mm.df[mm.df$specimenView == "left" | mm.df$specimenView == "9" & #facing left
+minnow.keep <- mm.df[mm.df$specimenView == "left" & 
                      mm.df$specimenCurved == "straight"&
                      mm.df$brightness == "normal" &
                      mm.df$colorIssue == "none" &
@@ -58,19 +58,19 @@ minnow.keep <- mm.df[mm.df$specimenView == "left" | mm.df$specimenView == "9" & 
                      mm.df$partsFolded == "False" &
                      mm.df$uniformBackground == "True",]
 
-length(unique(minnow.keep$arkID))
-length(unique(minnow.keep$scientificName))
+nrow(minnow.keep) #3656
+length(unique(minnow.keep$scientificName)) #98
 
-sampling.df$All_Minnows_Images_sp[2] <- paste0(length(unique(minnow.keep$arkID)),
+sampling.df$All_Minnows_Images_sp[2] <- paste0(nrow(minnow.keep),
                                                " (",
                                                length(unique(minnow.keep$scientificName)),
                                                ")")
 
 #for Burress et al. 2017
-length(unique(minnow.keep$arkID[minnow.keep$scientificName %in% b.sp]))
-length(unique(minnow.keep$scientificName[minnow.keep$scientificName %in% b.sp]))
+nrow(minnow.keep[minnow.keep$scientificName %in% b.sp,]) #595
+length(unique(minnow.keep$scientificName[minnow.keep$scientificName %in% b.sp])) #16
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[2] <- paste0(length(unique(minnow.keep$arkID[minnow.keep$scientificName %in% b.sp])),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[2] <- paste0(nrow(minnow.keep[minnow.keep$scientificName %in% b.sp,]),
                                                                " (",
                                                                length(unique(minnow.keep$scientificName[minnow.keep$scientificName %in% b.sp])),
                                                                ")")
@@ -79,13 +79,13 @@ sampling.df$Burress_et_al._2017_Overlap_Images_sp[2] <- paste0(length(unique(min
 
 sampling.df$Selection_Criteria[3] <- "Only INHS or UWZM (none from UWZM)"
 
-institutions <- c("INHS)", 
+institutions <- c("INHS", 
                   "UWZM")
 images.minnows.trim <- minnow.keep[minnow.keep$imageOwnerInstitutionCode %in% institutions,]
 
-unique(images.minnows.trim$ownerInstitutionCode.multi)
-nrow(images.minnows.trim)
-length(unique(images.minnows.trim$scientificName))
+unique(images.minnows.trim$imageOwnerInstitutionCode)
+nrow(images.minnows.trim) #2059
+length(unique(images.minnows.trim$scientificName)) #72
 
 sampling.df$All_Minnows_Images_sp[3] <- paste0(nrow(images.minnows.trim),
                                                " (",
@@ -93,114 +93,19 @@ sampling.df$All_Minnows_Images_sp[3] <- paste0(nrow(images.minnows.trim),
                                                ")")
 
 ##compared to Burress et al. 2017
-nrow(images.minnows.trim[images.minnows.trim$scientificName %in% b.sp,])
-length(unique(images.minnows.trim$scientificName[images.minnows.trim$scientificName %in% b.sp]))
+nrow(images.minnows.trim[images.minnows.trim$scientificName %in% b.sp,]) #273
+length(unique(images.minnows.trim$scientificName[images.minnows.trim$scientificName %in% b.sp])) #13
 
 sampling.df$Burress_et_al._2017_Overlap_Images_sp[3] <- paste0(nrow(images.minnows.trim[images.minnows.trim$scientificName %in% b.sp,]),
                                                                " (",
                                                                length(unique(images.minnows.trim$scientificName[images.minnows.trim$scientificName %in% b.sp])),
                                                                ")")
-#### 4. remove empty URLs ----
-
-sampling.df$Selection_Criteria[4] <- "No empty URLs"
-
-##ask if url is empty and remove if it is
-#1) see if url resolves
-#2) see if file is empty
-#3) if resolves & not empty, keep the path
-#4) remove all other paths
-
-#test with a known url
-##http://www.tubri.org/HDR/INHS/INHS_FISH_65294.jpg
-##INHS_FISH_33814.jpg
-test <- images.minnows.trim[images.minnows.trim$ARKID == "0040g17t",]
-empty <- c()
-for(i in 1:nrow(test)){
-  if(!isTRUE(valid_url(test$accessURI[i]))){
-    empty <- c(empty, test$accessURI[i])
-  }
-  else if(isTRUE(download_size(test$accessURI[i]) < 1048576)){ #smallest sized image we found
-    empty <- c(empty, test$accessURI[i])
-  }
-  else{
-    next
-  }
-}
-
-## Ensure all image URLs work
-empty <- c()
-for(i in 1:nrow(images.minnows.trim)){
-  if(!isTRUE(valid_url(images.minnows.trim$accessURI[i]))){
-    empty <- c(empty, images.minnows.trim$accessURI[i])
-  }
-  else if(isTRUE(download_size(images.minnows.trim$accessURI[i]) < 1048576)){ #smallest sized image we found
-    empty <- c(empty, images.minnows.trim$accessURI[i])
-  }
-  else{
-    next
-  }
-}
-
-length(empty) #28
-
-images.minnows.resolve <- images.minnows.trim[!(images.minnows.trim$accessURI %in% empty),]
-
-##new counts
-nrow(images.minnows.resolve) 
-length(unique(images.minnows.resolve$scientificName)) 
-
-sampling.df$All_Minnows_Images_sp[4] <- paste0(nrow(images.minnows.resolve),
-                                               " (",
-                                               length(unique(images.minnows.resolve$scientificName)),
-                                               ")")
-
-##compared to Burress et al. 2017
-nrow(images.minnows.resolve[images.minnows.resolve$scientificName %in% b.sp,]) #477
-length(unique(images.minnows.resolve$scientificName[images.minnows.resolve$scientificName %in% b.sp])) #17
-
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[4] <- paste0(nrow(images.minnows.resolve[images.minnows.resolve$scientificName %in% b.sp,]),
-                                                               " (",
-                                                               length(unique(images.minnows.resolve$scientificName[images.minnows.resolve$scientificName %in% b.sp])),
-                                                               ")")
-
-#### 5. At least 10 samples ----
-
-sampling.df$Selection_Criteria[5] <- "At least 10 samples"
-
-#get sample size (number of images per species)
-table.sp <- images.minnows.resolve %>%
-  dplyr::group_by(scientificName) %>%
-  dplyr::summarise(sample.size = n())
-nrow(table.sp) #111
-
-#retain only species for which there are 10 images
-table.sp.10 <- table.sp$scientificName[table.sp$sample.size >= 10]
-length(table.sp.10) #54 sp
-
-#trim dataset to match species with at least 10 species
-images.minnows.10 <- images.minnows.resolve[images.minnows.resolve$scientificName %in% table.sp.10,]
-nrow(images.minnows.10) 
-length(unique(images.minnows.10$scientificName)) 
-
-sampling.df$All_Minnows_Images_sp[5] <- paste0(nrow(images.minnows.10),
-                                               " (",
-                                               length(unique(images.minnows.10$scientificName)),
-                                               ")")
-
-#compared to Burress et al. 2017
-nrow(images.minnows.10[images.minnows.10$scientificName %in% b.sp,])
-length(unique(images.minnows.10$scientificName[images.minnows.10$scientificName %in% b.sp]))
-
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[5] <- paste0(nrow(images.minnows.10[images.minnows.10$scientificName %in% b.sp,]),
-                                                               " (",
-                                                               length(unique(images.minnows.10$scientificName[images.minnows.10$scientificName %in% b.sp])),
-                                                               ")")
 
 ### limit species
 if(isTRUE(checkpoint.limit_image == "")){
-  images.minnows.limit <- images.minnows.10
+  images.minnows.limit <- images.minnows.trim
 } else if(isTRUE(is.integer(checkpoint.limit_image))){
-  images.minnows.limit <- head(images.minnows.10, n=checkpoint.limit_image)
+  images.minnows.limit <- head(images.minnows.trim, n=checkpoint.limit_image)
 } else {
   print("The value for limit_image is invalid. Accepted values are '' or an integer.")
 }

--- a/Scripts/Presence_Absence_Analysis.R
+++ b/Scripts/Presence_Absence_Analysis.R
@@ -53,7 +53,6 @@ presence.meta <- merge(presence.df, mm.df,
 
 colnames(presence.meta)[colnames(presence.meta) == 'base_name'] <- 'ARKID'
 
-
 #### 4. sampling after segmentation ----
 
 sampling.df$Selection_Criteria[4] <- "After segmentation"

--- a/Scripts/Presence_Absence_Analysis.R
+++ b/Scripts/Presence_Absence_Analysis.R
@@ -47,7 +47,7 @@ colnames(meta.df) #loaded in from paths.R
 
 presence.meta <- merge(presence.df, meta.df,
                        by.x = "file_name",
-                       by.y = "original_file_name",
+                       by.y = "ARKID",
                        all.x = TRUE, all.y = FALSE)
 
 #### 8. sampling after segmentation ----
@@ -56,20 +56,20 @@ sampling.df$Selection_Criteria[8] <- "After segmentation"
 
 #check df (need to re-run w everything)
 nrow(presence.meta) #6297
-length(unique(presence.meta$scientific_name)) #41
+length(unique(presence.meta$scientificName)) #41
 
 sampling.df$All_Minnows_Images_sp[8] <- paste0(nrow(presence.meta),
                                                " (",
-                                               length(unique(presence.meta$scientific_name)),
+                                               length(unique(presence.meta$scientificName)),
                                                ")")
 
 #compare to Burress et al. 2017
-nrow(presence.meta[presence.meta$scientific_name %in% b.sp,]) #446
-length(unique(presence.meta$scientific_name[presence.meta$scientific_name %in% b.sp])) #8
+nrow(presence.meta[presence.meta$scientificName %in% b.sp,]) #446
+length(unique(presence.meta$scientificName[presence.meta$scientificName %in% b.sp])) #8
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[8] <- paste0(nrow(presence.meta[presence.meta$scientific_name %in% b.sp,]),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[8] <- paste0(nrow(presence.meta[presence.meta$scientificName %in% b.sp,]),
                                                                " (",
-                                                               length(unique(presence.meta$scientific_name[presence.meta$scientific_name %in% b.sp])),
+                                                               length(unique(presence.meta$scientificName[presence.meta$scientificName %in% b.sp])),
                                                                ")")
 ## 9. remove images that don't have a scale ----
 
@@ -87,16 +87,16 @@ presence.meta.scale <- presence.meta[!(presence.meta$base_name %in% errors$base_
 
 sampling.df$All_Minnows_Images_sp[9] <- paste0(nrow(presence.meta.scale),
                                                " (",
-                                               length(unique(presence.meta.scale$scientific_name.x)),
+                                               length(unique(presence.meta.scale$scientificName)),
                                                ")")
 
 #compare to Burress et al. 2017
-nrow(presence.meta.scale[presence.meta.scale$scientific_name %in% b.sp,]) #446
-length(unique(presence.meta.scale$scientific_name[presence.meta.scale$scientific_name %in% b.sp])) #8
+nrow(presence.meta.scale[presence.meta.scale$scientificName %in% b.sp,]) #446
+length(unique(presence.meta.scale$scientificName[presence.meta.scale$scientificName %in% b.sp])) #8
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[9] <- paste0(nrow(presence.meta.scale[presence.meta.scale$scientific_name.x %in% b.sp,]),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[9] <- paste0(nrow(presence.meta.scale[presence.meta.scale$scientificName %in% b.sp,]),
                                                                " (",
-                                                               length(unique(presence.meta.scale$scientific_name.x[presence.meta.scale$scientific_name.x %in% b.sp])),
+                                                               length(unique(presence.meta.scale$scientificName[presence.meta.scale$scientificName %in% b.sp])),
                                                                ")")
 
 write.csv(presence.meta.scale,
@@ -111,21 +111,20 @@ write.csv(presence.meta.scale,
 #not using information about dimensions of the image
 df <- select(presence.meta.scale, - c("adipos_fin_number", "adipos_fin_percentage",
                                       "caudal_fin_ray_number", "caudal_fin_ray_percentage",
-                                      "alt_fin_ray_number", "alt_fin_ray_percentage",
-                                      "width", "size", "height"))
+                                      "alt_fin_ray_number", "alt_fin_ray_percentage"))
 
 ## how many 0s are there? ====
 no.abs <- df[apply(df, 1, function(row) all(row !=0 )), ]  # Remove zero-rows
 nrow(df) - nrow(no.abs) #40; 10 from Burress
 
 ## how many have all fins? ====
-df.fin.per <- select(df, c("scientific_name", contains("percentage")))
+df.fin.per <- select(df, c("scientificName", contains("percentage")))
 df.fin.per$total <- rowSums(df.fin.per[ , 2:9], na.rm=TRUE)
 nrow(df.fin.per[df.fin.per$total > 8,]) #none are perfect
 
 #### 10. sampling of data ----
 df.fin.per.sample <- df.fin.per %>%
-  group_by(scientific_name) %>%
+  group_by(scientificName) %>%
   summarize(sample = n()) %>%
   as.data.frame()
 
@@ -133,16 +132,16 @@ sampling.df$Selection_Criteria[10] <- "All Traits Present"
 
 sampling.df$All_Minnows_Images_sp[10] <- paste0(nrow(df.fin.per.sample),
                                                " (",
-                                               length(unique(df.fin.per.sample$scientific_name.x)),
+                                               length(unique(df.fin.per.sample$scientificName)),
                                                ")")
 
 # compare to burress
-nrow(df.fin.per.sample[df.fin.per.sample$scientific_name %in% b.sp,]) #446
-length(unique(df.fin.per.sample$scientific_name[df.fin.per.sample$scientific_name %in% b.sp])) #8
+nrow(df.fin.per.sample[df.fin.per.sample$scientificName %in% b.sp,]) #446
+length(unique(df.fin.per.sample$scientificName[df.fin.per.sample$scientificName %in% b.sp])) #8
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[10] <- paste0(nrow(df.fin.per.sample[df.fin.per.sample$scientific_name.x %in% b.sp,]),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[10] <- paste0(nrow(df.fin.per.sample[df.fin.per.sample$scientificName %in% b.sp,]),
                                                                 " (",
-                                                                length(unique(df.fin.per.sample$scientific_name.x[df.fin.per.sample$scientific_name.x %in% b.sp])),
+                                                                length(unique(df.fin.per.sample$scientificName[df.fin.per.sample$scientificName %in% b.sp])),
                                                                 ")")
 
 #### visualize sampling data ----
@@ -199,7 +198,7 @@ stats <- df %>%
 
 ## fins by species ====
 stats.sp <- df %>%
-  group_by(scientific_name) %>%
+  group_by(scientificName) %>%
   summarise(sample = n(),
             min.head = min(head_percentage),
             max.head = max(head_percentage),
@@ -240,7 +239,7 @@ stats.sp <- df %>%
 #need to have matrix in the order we already want
 #need to label rows
 stats.sp.sort <- stats.sp[order(stats.sp$sample, decreasing = TRUE),]
-row.names(stats.sp.sort) <- paste(stats.sp.sort$scientific_name, " (", stats.sp.sort$sample, ")", sep = "")
+row.names(stats.sp.sort) <- paste(stats.sp.sort$scientificName, " (", stats.sp.sort$sample, ")", sep = "")
 #head, eye, trunk, dorsal, caudal, anal, pelvic, pectoral
 colnames(stats.sp.sort) #these are in the correct order
 
@@ -326,25 +325,25 @@ df.fin.95.3 <- df.fin.per[df.fin.per$head_percentage > .95 &
                           df.fin.per$eye_percentage > .95 &
                           df.fin.per$trunk_percentage > .95,]
 nrow(df.fin.95.3) #6205 images
-length(unique(df.fin.95.3$scientific_name)) #41 species
+length(unique(df.fin.95.3$scientificName)) #41 species
 
 sampling.df$All_Minnows_Images_sp[11] <- paste0(nrow(df.fin.95.3),
                                                " (",
-                                               length(unique(df.fin.95.3$scientific_name)),
+                                               length(unique(df.fin.95.3$scientificName)),
                                                ")")
 
 ## compare to Burress et al. 2017
-df.fin.b.95.3 <- df.fin.95.3[df.fin.95.3$scientific_name %in% b.sp,]
+df.fin.b.95.3 <- df.fin.95.3[df.fin.95.3$scientificName %in% b.sp,]
 nrow(df.fin.b.95.3) #445
-length(unique(df.fin.b.95.3$scientific_name)) #8
+length(unique(df.fin.b.95.3$scientificName)) #8
 
 sampling.df$Burress_et_al._2017_Overlap_Images_sp[11] <- paste0(nrow(df.fin.b.95.3),
                                                                " (",
-                                                               length(unique(df.fin.b.95.3$scientific_name)),
+                                                               length(unique(df.fin.b.95.3$scientificName)),
                                                                ")")
 
 #how is the sampling for these species?
-b.sampling <- as.data.frame(table(df.fin.b.95.3$scientific_name))
+b.sampling <- as.data.frame(table(df.fin.b.95.3$scientificName))
 colnames(b.sampling) <- c("Scientific_Name", "Sample_Size")
 write.csv(b.sampling,
           file = sampling_species_burress_path,
@@ -360,19 +359,19 @@ df.fin.95 <- df.fin.per[df.fin.per$head_percentage > .95 &
                         df.fin.per$pelvic_fin_percentage > .95 &
                         df.fin.per$pectoral_fin_percentage > .95,]
 nrow(df.fin.95) #4663
-length(unique(df.fin.95$scientific_name)) #41
+length(unique(df.fin.95$scientificName)) #41
 
-sort(table(df.fin.95$scientific_name)) #3 species have under 10 samples; lose 20 images
+sort(table(df.fin.95$scientificName)) #3 species have under 10 samples; lose 20 images
 
 ## how much does the total dataset get reduced for the 3 segmented traits at a 95% cut off?
 df.fin.95.3 <- df.fin.per[df.fin.per$head_percentage > .95 &
                           df.fin.per$eye_percentage > .95 &
                           df.fin.per$trunk_percentage > .95,]
 nrow(df.fin.95.3) #6205; a lot more!
-length(unique(df.fin.95.3$scientific_name)) #41
+length(unique(df.fin.95.3$scientificName)) #41
 
 # how is sampling?
-sampling.95.3 <- as.data.frame(sort(table(df.fin.95.3$scientific_name)))
+sampling.95.3 <- as.data.frame(sort(table(df.fin.95.3$scientificName)))
 colnames(sampling.95.3) <- c("Scientific_Name", "Sample_Size")
 nrow(sampling.95.3) #41 sp; don't lose any!
 

--- a/Scripts/Presence_Absence_Analysis.R
+++ b/Scripts/Presence_Absence_Analysis.R
@@ -46,38 +46,38 @@ write.csv(presence.df,
 colnames(mm.df) #loaded in from paths.R
 
 presence.meta <- merge(presence.df, mm.df,
-                       by.x = "file_name",
+                       by.x = "base_name",
                        by.y = "ARKID",
                        all.x = TRUE, all.y = FALSE)
 
-#### 8. sampling after segmentation ----
+#### 4. sampling after segmentation ----
 
-sampling.df$Selection_Criteria[8] <- "After segmentation"
+sampling.df$Selection_Criteria[4] <- "After segmentation"
 
 #check df (need to re-run w everything)
-nrow(presence.meta) #6297
-length(unique(presence.meta$scientificName)) #41
+nrow(presence.meta) #284
+length(unique(presence.meta$scientificName)) #4
 
-sampling.df$All_Minnows_Images_sp[8] <- paste0(nrow(presence.meta),
+sampling.df$All_Minnows_Images_sp[4] <- paste0(nrow(presence.meta),
                                                " (",
                                                length(unique(presence.meta$scientificName)),
                                                ")")
 
 #compare to Burress et al. 2017
-nrow(presence.meta[presence.meta$scientificName %in% b.sp,]) #446
-length(unique(presence.meta$scientificName[presence.meta$scientificName %in% b.sp])) #8
+nrow(presence.meta[presence.meta$scientificName %in% b.sp,]) #9
+length(unique(presence.meta$scientificName[presence.meta$scientificName %in% b.sp])) #3
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[8] <- paste0(nrow(presence.meta[presence.meta$scientificName %in% b.sp,]),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[4] <- paste0(nrow(presence.meta[presence.meta$scientificName %in% b.sp,]),
                                                                " (",
                                                                length(unique(presence.meta$scientificName[presence.meta$scientificName %in% b.sp])),
                                                                ")")
-## 9. remove images that don't have a scale ----
+## 5. remove images that don't have a scale ----
 
-sampling.df$Selection_Criteria[9] <- "Has ruler scale"
+sampling.df$Selection_Criteria[5] <- "Has ruler scale"
 
 unique(presence.meta$ruler_unit) #None means no scale was detected or extracted
 errors <- presence.meta[presence.meta$ruler_unit == "None",] %>% tidyr::drop_na(ruler_unit)
-nrow(errors) #18 images
+nrow(errors) #11 images
 
 write.csv(errors,
           file = file.path(results, "df.missing.scale.csv"),
@@ -85,16 +85,16 @@ write.csv(errors,
 
 presence.meta.scale <- presence.meta[!(presence.meta$base_name %in% errors$base_name),]
 
-sampling.df$All_Minnows_Images_sp[9] <- paste0(nrow(presence.meta.scale),
+sampling.df$All_Minnows_Images_sp[5] <- paste0(nrow(presence.meta.scale),
                                                " (",
                                                length(unique(presence.meta.scale$scientificName)),
                                                ")")
 
 #compare to Burress et al. 2017
-nrow(presence.meta.scale[presence.meta.scale$scientificName %in% b.sp,]) #446
-length(unique(presence.meta.scale$scientificName[presence.meta.scale$scientificName %in% b.sp])) #8
+nrow(presence.meta.scale[presence.meta.scale$scientificName %in% b.sp,]) #9
+length(unique(presence.meta.scale$scientificName[presence.meta.scale$scientificName %in% b.sp])) #3
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[9] <- paste0(nrow(presence.meta.scale[presence.meta.scale$scientificName %in% b.sp,]),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[6] <- paste0(nrow(presence.meta.scale[presence.meta.scale$scientificName %in% b.sp,]),
                                                                " (",
                                                                length(unique(presence.meta.scale$scientificName[presence.meta.scale$scientificName %in% b.sp])),
                                                                ")")
@@ -115,31 +115,31 @@ df <- select(presence.meta.scale, - c("adipos_fin_number", "adipos_fin_percentag
 
 ## how many 0s are there? ====
 no.abs <- df[apply(df, 1, function(row) all(row !=0 )), ]  # Remove zero-rows
-nrow(df) - nrow(no.abs) #40; 10 from Burress
+nrow(df) - nrow(no.abs) #6
 
 ## how many have all fins? ====
 df.fin.per <- select(df, c("scientificName", contains("percentage")))
 df.fin.per$total <- rowSums(df.fin.per[ , 2:9], na.rm=TRUE)
 nrow(df.fin.per[df.fin.per$total > 8,]) #none are perfect
 
-#### 10. sampling of data ----
+#### 6. sampling of data ----
 df.fin.per.sample <- df.fin.per %>%
   group_by(scientificName) %>%
   summarize(sample = n()) %>%
   as.data.frame()
 
-sampling.df$Selection_Criteria[10] <- "All Traits Present"
+sampling.df$Selection_Criteria[6] <- "All Traits Present"
 
-sampling.df$All_Minnows_Images_sp[10] <- paste0(nrow(df.fin.per.sample),
+sampling.df$All_Minnows_Images_sp[6] <- paste0(nrow(df.fin.per.sample),
                                                " (",
                                                length(unique(df.fin.per.sample$scientificName)),
                                                ")")
 
 # compare to burress
-nrow(df.fin.per.sample[df.fin.per.sample$scientificName %in% b.sp,]) #446
-length(unique(df.fin.per.sample$scientificName[df.fin.per.sample$scientificName %in% b.sp])) #8
+nrow(df.fin.per.sample[df.fin.per.sample$scientificName %in% b.sp,]) #
+length(unique(df.fin.per.sample$scientificName[df.fin.per.sample$scientificName %in% b.sp])) #
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[10] <- paste0(nrow(df.fin.per.sample[df.fin.per.sample$scientificName %in% b.sp,]),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[6] <- paste0(nrow(df.fin.per.sample[df.fin.per.sample$scientificName %in% b.sp,]),
                                                                 " (",
                                                                 length(unique(df.fin.per.sample$scientificName[df.fin.per.sample$scientificName %in% b.sp])),
                                                                 ")")
@@ -234,7 +234,7 @@ stats.sp <- df %>%
             sd.pect = sd(pectoral_fin_percentage)) %>%
   as.data.frame()
 
-#### Head Map ----
+#### Heat Map ----
 
 #need to have matrix in the order we already want
 #need to label rows
@@ -283,8 +283,9 @@ colnames(stats.sp.sd) #in correct order
 
 melt_stats_sd <- melt(stats.sp.sd)
 head(melt_stats_sd)
+melt_stats_sd.na <- melt_stats_sd %>% drop_na(value)
 
-hm.sd <- ggplot(melt_stats_avg, aes(Var2, Var1)) +
+hm.sd <- ggplot(melt_stats_sd.na, aes(Var2, Var1)) +
   geom_tile(aes(fill = value), color = "white") +
   scale_fill_gradient(low = "#FFFFCC", high = "#800026") +
   labs( x = "Trait",
@@ -294,11 +295,11 @@ hm.sd <- ggplot(melt_stats_avg, aes(Var2, Var1)) +
   theme(panel.grid.major = element_blank(), panel.grid.minor = element_blank(),
         panel.background = element_blank(), axis.line = element_line(colour = "black"))
 
-ggsave(hm.avg,
+ggsave(hm.sd,
        file = heatmap_sd_blob_path,
        width = 14, height = 20, units = "cm")
 
-max(melt_stats_sd$value) #.34 largest standard deviation
+max(melt_stats_sd$value, na.rm = TRUE) #0.58 largest standard deviation
 
 #a lot of species are missing fins, like dorsal, anal, pelvic, pectoral
 #caudal, eye, trunk perform the best
@@ -316,9 +317,9 @@ df.fin.0 <- df.fin.per[df.fin.per$head_percentage > 0 &
 nrow(df.fin.per) #6297
 nrow(df.fin.0) #6297, no loss
 
-## 11. 95% min for blob ====
+## 7. 95% min for blob ====
 
-sampling.df$Selection_Criteria[11] <- "95% blobb for head, eye, trunk"
+sampling.df$Selection_Criteria[7] <- "95% blobb for head, eye, trunk"
 
 #based on visualizations above, we decided to keep .95 blobs; only for the traits we care about
 df.fin.95.3 <- df.fin.per[df.fin.per$head_percentage > .95 &
@@ -327,7 +328,7 @@ df.fin.95.3 <- df.fin.per[df.fin.per$head_percentage > .95 &
 nrow(df.fin.95.3) #6205 images
 length(unique(df.fin.95.3$scientificName)) #41 species
 
-sampling.df$All_Minnows_Images_sp[11] <- paste0(nrow(df.fin.95.3),
+sampling.df$All_Minnows_Images_sp[7] <- paste0(nrow(df.fin.95.3),
                                                " (",
                                                length(unique(df.fin.95.3$scientificName)),
                                                ")")
@@ -337,7 +338,7 @@ df.fin.b.95.3 <- df.fin.95.3[df.fin.95.3$scientificName %in% b.sp,]
 nrow(df.fin.b.95.3) #445
 length(unique(df.fin.b.95.3$scientificName)) #8
 
-sampling.df$Burress_et_al._2017_Overlap_Images_sp[11] <- paste0(nrow(df.fin.b.95.3),
+sampling.df$Burress_et_al._2017_Overlap_Images_sp[7] <- paste0(nrow(df.fin.b.95.3),
                                                                " (",
                                                                length(unique(df.fin.b.95.3$scientificName)),
                                                                ")")

--- a/Scripts/Presence_Absence_Analysis.R
+++ b/Scripts/Presence_Absence_Analysis.R
@@ -48,7 +48,11 @@ colnames(mm.df) #loaded in from paths.R
 presence.meta <- merge(presence.df, mm.df,
                        by.x = "base_name",
                        by.y = "ARKID",
-                       all.x = TRUE, all.y = FALSE)
+                       all.x = TRUE,
+                       all.y = FALSE)
+
+colnames(presence.meta)[colnames(presence.meta) == 'base_name'] <- 'ARKID'
+
 
 #### 4. sampling after segmentation ----
 
@@ -83,7 +87,7 @@ write.csv(errors,
           file = file.path(results, "df.missing.scale.csv"),
           row.names = FALSE)
 
-presence.meta.scale <- presence.meta[!(presence.meta$base_name %in% errors$base_name),]
+presence.meta.scale <- presence.meta[!(presence.meta$ARKID %in% errors$ARKID),]
 
 sampling.df$All_Minnows_Images_sp[5] <- paste0(nrow(presence.meta.scale),
                                                " (",

--- a/Scripts/Presence_Absence_Analysis.R
+++ b/Scripts/Presence_Absence_Analysis.R
@@ -278,7 +278,8 @@ colnames(stats.sp.sd) #in correct order
 
 melt_stats_sd <- melt(stats.sp.sd)
 head(melt_stats_sd)
-melt_stats_sd.na <- melt_stats_sd %>% drop_na(value)
+melt_stats_sd.na <- melt_stats_sd %>% 
+  tidyr::drop_na(value)
 
 hm.sd <- ggplot(melt_stats_sd.na, aes(Var2, Var1)) +
   geom_tile(aes(fill = value), color = "white") +

--- a/Scripts/Presence_Absence_Analysis.R
+++ b/Scripts/Presence_Absence_Analysis.R
@@ -43,9 +43,9 @@ write.csv(presence.df,
 
 #### merge with metadata ----
 #combine with metadata to get taxonomic hierarchy
-colnames(meta.df) #loaded in from paths.R
+colnames(mm.df) #loaded in from paths.R
 
-presence.meta <- merge(presence.df, meta.df,
+presence.meta <- merge(presence.df, mm.df,
                        by.x = "file_name",
                        by.y = "ARKID",
                        all.x = TRUE, all.y = FALSE)

--- a/Scripts/Presence_Absence_Analysis.R
+++ b/Scripts/Presence_Absence_Analysis.R
@@ -247,11 +247,6 @@ colnames(stats.sp.sort) #these are in the correct order
 stats.sp.trim <- stats.sp[,-c(1:2)]
 stats.sp.trim <- as.matrix(stats.sp.trim)
 
-hm <- heatmap(stats.sp.trim,
-              labRow = rownames(stats.sp.trim),
-              labCol = colnames(stats.sp.trim),
-              main = "Heat Map")
-
 ## average ====
 stats.sp.avg <- select(stats.sp.sort, contains("avg."))
 colnames(stats.sp.avg) #in correct order

--- a/Scripts/fish-air.R
+++ b/Scripts/fish-air.R
@@ -1,0 +1,44 @@
+# Functions to read a Fish-AIR CSV applying column names based on term IRI
+
+require(XML)
+
+get_term_to_col_idx <- function(meta_xml_path, file_location, archive_child_names = c("core", "extension")) {
+  # Returns a list of term URI -> R column indexes
+  
+  # Parse meta.xml file creating a list of fields for the file_location(aka filename)
+  data <- XML::xmlParse(meta_xml_path, asTree=TRUE)
+  xml_data <- XML::xmlToList(data)
+  items <- xml_data[names(xml_data) %in% archive_child_names]
+  file_columns <- items[lapply(items, function(x) x$files$location) == file_location]
+  target_file_columns <- file_columns[[1]]
+  
+  # Filter out fields that do not have both "index" and "term"
+  has_index_and_term_names <- function(field) {
+    "index" %in% names(field) & "term" %in% names(field)
+  }
+  valid_file_columns <- target_file_columns[unlist(lapply(target_file_columns, has_index_and_term_names))]
+  
+  # Create a list from term URI -> column index
+  # increment since R indexing starts at 1 so
+  indexes <- vapply(valid_file_columns, function(x) as.numeric(x["index"])+1, numeric(1)) 
+  names(indexes) <- vapply(valid_file_columns, function(x) x["term"], character(1))
+  indexes
+}
+
+fa_read_csv <- function(csv_path, meta_xml_path, term_to_colname) {
+  # Read Fish-AIR CSV file
+  df <- read.csv(file = csv_path)
+  
+  # Create a list from term URI -> R column indexes
+  term_to_col_idx <- get_term_to_col_idx(meta_xml_path, basename(csv_path))
+  
+  # Filter to the columns requested in term_to_colname
+  col_idx_list = unlist(lapply(names(term_to_colname), function(term) {term_to_col_idx[term]}), use.names = FALSE)
+  df_filtered <- df[, col_idx_list]
+  
+  # Change column names to match those in term_to_colname
+  new_names = unlist(lapply(names(term_to_colname), function(term) {term_to_colname[term]}), use.names = FALSE)
+  names(df_filtered) <- new_names
+
+  df_filtered
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,7 @@ Burress: Files/Previous Fish Measurements - Burress et al. 2016.csv
 Burress_DOI: doi:10.5072/FK2/KLN3CS
 
 # Input settings
-limit_images: 5 #if "" will run all, otherwise must input in integer
+limit_images: 20 #if "" will run all, otherwise must input in integer
 
 # Output paths
 Minnow_Filtered: Results/minnow.filtered.from.iqm.csv

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,10 +1,10 @@
 # "Name:" becomes the object for the Snakefile
 
 # Input paths
-Image_DOI: doi:10.5072/FK2/QOHJGD
-File_Metadata: Files/Fish-AIR/Tulane/dtsv562685gm/meta.xml
-Image_Metadata: Files/Fish-AIR/Tulane/dtsv562685gm/multimedia.csv
-Image_Quality_Metadata: Files/Fish-AIR/Tulane/dtsv562685gm/imageQualityMetadata.csv
+Image_DOI: doi:10.5072/FK2/GYHRV8
+File_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/meta.xml
+Image_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/multimedia.csv
+Image_Quality_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/imageQualityMetadata.csv
 Burress: Files/Previous Fish Measurements - Burress et al. 2016.csv
 Burress_DOI: doi:10.5072/FK2/KLN3CS
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,9 +9,10 @@ Burress: Files/Previous Fish Measurements - Burress et al. 2016.csv
 Burress_DOI: doi:10.5072/FK2/KLN3CS
 
 # Input settings
-limit_images: "" #if "" will run all, otherwise must input in integer
+limit_images: 5 #if "" will run all, otherwise must input in integer
 
 # Output paths
+Minnow_Filtered: Results/minnow.filtered.from.iqm.csv
 Burress_Minnow_Filtered: Results/burress.minnow.sp.filtered.from.iqm.csv
 Sampling: Results/sampling.df.IQM.csv
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,14 +1,15 @@
 # "Name:" becomes the object for the Snakefile
 
 # Input paths
-#TU_FISH: Files/TU_FISH_dtsrc20qp16v.zip
-TU_FISH_DOI: doi:10.5072/FK2/VBAEXS
-Image_Metadata: Files/Tulane/Fish/extendedImageMetadata.csv
-Image_Quality_Metadata: Files/Tulane/Fish/imageQualityMetadata.csv
-Multimedia: Files/Tulane/Fish/multimedia.csv
+Image_DOI: doi:10.5072/FK2/QOHJGD
+File_Metadata: Files/Fish-AIR/Tulane/dtsv562685gm/meta.xml
+Image_Metadata: Files/Fish-AIR/Tulane/dtsv562685gm/multimedia.csv
+Image_Quality_Metadata: Files/Fish-AIR/Tulane/dtsv562685gm/imageQualityMetadata.csv
 Burress: Files/Previous Fish Measurements - Burress et al. 2016.csv
 Burress_DOI: doi:10.5072/FK2/KLN3CS
-limit_images: "10" #if "" will run all, otherwise must input in integer
+
+# Input settings
+limit_images: "" #if "" will run all, otherwise must input in integer
 
 # Output paths
 Burress_Minnow_Filtered: Results/burress.minnow.sp.filtered.from.iqm.csv

--- a/debug-workflow.sh
+++ b/debug-workflow.sh
@@ -13,9 +13,8 @@ export SBATCH_ACCOUNT=$SLURM_JOB_ACCOUNT
 # Configure Snakemake to run up to 20 jobs at once
 NUM_JOBS=20
 
-module load miniconda3
+module load miniconda3/4.10.3-py37
 source activate snakemake
-module load R/4.2.1-gnu11.2
 snakemake \
     --jobs $NUM_JOBS \
     --use-singularity \

--- a/dependencies.R
+++ b/dependencies.R
@@ -28,6 +28,11 @@ remotes::install_version("yaml",
                          version = "2.3.5",
                          upgrade = "never")
 
+#read xml files
+remotes::install_version("XML",
+                         version = "3.99-0.11",
+                         upgrade = "never")
+
 #data manipulation packages
 remotes::install_version("stringr",
                          version = "1.4.0",
@@ -59,7 +64,7 @@ remotes::install_version("ggpubr",
                          upgrade = "never")
 
 ##load everything
-p <- c("rjson",
+p <- c("rjson", "XML",
        "stringr", "tidyr", "reshape2", "dplyr",
        "moments",
        "ggplot2", "RColorBrewer", "ggpubr")

--- a/paths.R
+++ b/paths.R
@@ -12,4 +12,4 @@ files <- "Files" # folder with files to read into scripts
 results <- "Results" # folder to store outputs of scripts
 figures <- file.path("Results", "Figures")
 workflow <- file.path("Workflow")
-presence <- file.path("segmentation", "Morphology", "Presence") # this data is produced by the BGNN_Snakemake workflow
+presence <- file.path("Morphology", "Presence") # this data is produced by the BGNN_Snakemake workflow

--- a/run-workflow.sh
+++ b/run-workflow.sh
@@ -13,9 +13,8 @@ export SBATCH_ACCOUNT=$SLURM_JOB_ACCOUNT
 # Configure Snakemake to run up to 20 jobs at once
 NUM_JOBS=20
 
-module load miniconda3
+module load miniconda3/4.10.3-py37
 source activate snakemake
-module load R/4.2.1-gnu11.2
 snakemake \
     --jobs $NUM_JOBS \
     --profile slurm/ \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -26,6 +26,7 @@ rule download_fish_air_data:
         config=DATAVERSE_CONFIG_PATH
     container:
         DATAVERSE_CONTAINER
+    shell: 'DATAVERSE_CONFIG_PATH={params.config} dva download {params.doi} Files/'
 
 rule download_burress:
     output: config["Burress"]

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -17,23 +17,15 @@ rule all:
         heatmap_avg_blob_image=config["Heatmap_Avg_Blob_Image"],
         heatmap_sd_blob_image=config["Heatmap_SD_Blob_Image"]
 
-rule download_image_metadata:
-    output: config["Image_Metadata"]
+rule download_fish_air_data:
+    output:
+        config["Image_Metadata"],
+        config["Image_Quality_Metadata"]
     params:
-        doi=config["Image_Metadata_DOI"],
+        doi=config["Image_DOI"],
         config=DATAVERSE_CONFIG_PATH
     container:
         DATAVERSE_CONTAINER
-    shell: 'DATAVERSE_CONFIG_PATH={params.config} dva download {params.doi} Files/'
-
-rule download_image_quality_metadata:
-    output: config["Image_Quality_Metadata"]
-    params:
-        doi=config["Image_Quality_Metadata_DOI"],
-        config=DATAVERSE_CONFIG_PATH
-    container:
-        DATAVERSE_CONTAINER
-    shell: 'DATAVERSE_CONFIG_PATH={params.config} dva download {params.doi} Files/'
 
 rule download_burress:
     output: config["Burress"]
@@ -73,7 +65,24 @@ module segmentation:
     # Store all files in a subdirectory
     prefix: "segmentation"
 
-use rule download_image from segmentation as seg_download_image
+def get_image_url(wildcards):
+    """
+    Read the filtered CSV to lookup a URL(accessURI) for a file via the image wildcard(ARKID)
+    These column names do not need to be crosswalked with meta.xml because we are using the 
+    filtered CSV file that has already performed that step.
+    """
+    filename = checkpoints.select_minnow_images.get().output[0]
+    df = pd.read_csv(filename)
+    # The segmentation workflow names images 'Images/{image}.jpg' so for us `image` is an ARKID
+    row = df[df["ARKID"] == wildcards.image]
+    url = row["accessURI"].item()
+    return url
+
+use rule download_image from segmentation as seg_download_image with:
+   input: config["Burress_Minnow_Filtered"]
+   container: 'docker://quay.io/biocontainers/gnu-wget:1.18--h60da905_7'
+   params: download_link=get_image_url
+
 use rule generate_metadata from segmentation as seg_generate_metadata
 use rule transform_metadata from segmentation as seg_transform_metadata
 use rule crop_image from segmentation as seg_crop_image
@@ -90,29 +99,30 @@ rule create_morphological_analysis:
     shell:
         'Morphology_main.py {input.image} --metadata {input.metadata} {output} > {log} 2>&1'
 
-def get_image_names(csv_filename):
+def get_arkid_list(csv_filename):
+    """
+    Read the filtered CSV to lookup a list of ARKIDs.
+    These column names do not need to be crosswalked with meta.xml because we are using the 
+    filtered CSV file that has already performed that step.
+    """
     df = pd.read_csv(csv_filename)
-    # Create 'name' column by removing the filename extension from 'original_file_name'
-    names = df['original_file_name'].apply(lambda x : os.path.splitext(x)[0])
+    names = df['ARKID']
     return names.tolist()
 
-def presence_absence_analysis_inputs(wildcards):
+def presence_absence_files(wildcards):
     # Returns output morphology presence filenames based on Burress_Minnow_Filtered
     with checkpoints.select_minnow_images.get(**wildcards).output[0].open() as f:
-       names = get_image_names(f)
-    presence_files = [f"Morphology/Presence/{i}_presence.json" for i in names]
-    return {
-        "presence_files": presence_files,
-        "sampling": config["Sampling"],
-        "image_metadata": config["Image_Metadata"],
-        "image_quality_metadata": config["Image_Quality_Metadata"],
-        "burress": config["Burress"],
-        "library": "Library"
-    }
+       arkids = get_arkid_list(f)
+    return [f"Morphology/Presence/{i}_presence.json" for i in arkids]
 
 rule presence_absence_analysis:
     input:
-       unpack(presence_absence_analysis_inputs)
+       presence_files=presence_absence_files,
+       sampling=config["Sampling"],
+       image_metadata=config["Image_Metadata"],
+       image_quality_metadata=config["Image_Quality_Metadata"],
+       burress=config["Burress"],
+       library="Library"
     output:
        presence_absence_matrix=config["Presence_Absence_Matrix"],
        sampling_species_burress=config["Sampling_Species_Burress"],


### PR DESCRIPTION
Changes the workflow to use a new dataset from https://fishair.org/ which replaces https://bgnn.tulane.edu/.
The workflow now uses term IRIs to identify the columns used in the Fish-AIR data.
The files created for each fish image are now named using an [Ark ID](https://arks.org/).
The Fish-AIR files are now stored together within datacommons under a [single dataset](https://datacommons.tdai.osu.edu/dataset.xhtml?persistentId=doi:10.5072/FK2/GYHRV8&version=DRAFT) so the important metadata is kept.
Part of the Fish-AIR metadata is XML file so the R `XML` package has been added. As part of this change the R environment via a conda package to increase portability.


Fixes #36
Fixes #37
Fixes #38 
Fixes #39