### PR TITLE
Update Core Workflow and Fish-AIR download

### DIFF
--- a/Files/Burress.md
+++ b/Files/Burress.md
@@ -1,0 +1,6 @@
+# Previous Fish Measurements - Burress et al. 2016
+The [Previous Fish Measurements - Burress et al. 2016.csv](Previous&#32;Fish&#32;Measurements&#32;-&#32;Burress&#32;et&#32;al.&#32;2016.csv) file contains previous minnow measurements. The original file can be downloaded here: https://onlinelibrary.wiley.com/action/downloadSupplement?doi=10.1111%2Fjeb.13024&file=jeb13024-sup-0001-SupInfo.docx. I created a .csv file of Table S3. The columns are: Species, N, SL, HL, ED, HD, SnL, EP, RGL, MA. More information about the columns can be found in the supplementary info. The original paper can be found here: https://onlinelibrary.wiley.com/doi/full/10.1111/jeb.13024. (2022-07-13)
+
+
+## Publication
+Burress, E.D., Holcomb, J.M., Tan, M. and Armbruster, J.W., 2017. Ecological diversification associated with the benthic‐to‐pelagic transition by North American minnows. Journal of Evolutionary Biology, 30(3), pp.549-560. doi: 10.1111/jeb.13024

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Finally, with the help of the Duke Team, we create an automated workflow.
 - [init.R](https://github.com/hdr-bgnn/Minnow_Traits/blob/streamline/Scripts/init.R): code to load functions in [Functions](https://github.com/hdr-bgnn/Minnow_Traits/tree/streamline/Scripts/Functions)
 
 *Files*
-- [Previous_Measurements](https://github.com/hdr-bgnn/Minnow_Segmented_Traits/blob/streamline/Files/Previoius_Measurements.xlsx): a file of measurements of minnow traits by  found in the supplemental information. See [Burress.md](Files/Burress.md) for more details.
+- [Previous_Measurements](Files/Previous%20Fish%20Measurements%20-%20Burress%20et%20al.%202016.csv): a file of measurements of minnow traits by  found in the supplemental information. See [Burress.md](Files/Burress.md) for more details.
 
 *Results*
 - a folder for the outputs from the workflow
@@ -45,8 +45,11 @@ Finally, with the help of the Duke Team, we create an automated workflow.
 
 ### Data Files
 
-All input files are stored in the [Fish Traits](https://covid-commons.osu.edu/dataverse/fish-traits) dataverse hosted by OSU.
+The [Previous_Measurements](Files/Previous%20Fish%20Measurements%20-%20Burress%20et%20al.%202016.csv) file is included in this repository.
 
+The Fish-AIR input files will be downloaded from the [Fish-AIR API](https://fishair.org/).
+This requires a [Fish-AIR API key](https://fishair.org/) be added to `Fish_AIR_API_Key` in `config/config.yaml`.
+Alternatively you can download the Fish-AIR input files from Dryad and place them in the `Files/Fish-AIR/Tulane` directory.
 
 ### Components
 
@@ -168,32 +171,6 @@ mkdir Library
 module load cmake #defaukts to version on node
 module load R/4.2.1-gnu11.2
 Rscript dependencies.R
-```
-
-### Dataverse configuration
-
-To download the unpublished input files from our Dataverse instance requires
-supplying the URL to the instance and a Dataverse API Token.
-The URL and API Token need to be placed into a config file stored in your home
-directory name ".dataverse".
-
-To find your token visit [datacommons.tdai.osu.edu]( https://datacommons.tdai.osu.edu/),
-after logging in click your name in the top right corner, click API Token.
-You should see a screen for managing your API Token.
-
-Then run the following command to create your config file:
-
-```
-singularity run docker://ghcr.io/imageomics/dataverse-access:0.0.3 dva setup
-```
-
-This command will download the dva container and create your `~/.dataverse` config file.
-You will see two prompts. For the `URL` prompt enter `https://datacommons.tdai.osu.edu/`.
-For `API Token` prompt enter your API token.
-
-```
-Enter Dataverse URL: https://datacommons.tdai.osu.edu/
-Enter your Dataverse API Token: <yourtoken>
 ```
 
 ### Limit images

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Finally, with the help of the Duke Team, we create an automated workflow.
 - [init.R](https://github.com/hdr-bgnn/Minnow_Traits/blob/streamline/Scripts/init.R): code to load functions in [Functions](https://github.com/hdr-bgnn/Minnow_Traits/tree/streamline/Scripts/Functions)
 
 *Files*
-- [Previous_Measurements](https://github.com/hdr-bgnn/Minnow_Segmented_Traits/blob/streamline/Files/Previoius_Measurements.xlsx): a file of measurements of minnow traits by  found in the supplemental information
+- [Previous_Measurements](https://github.com/hdr-bgnn/Minnow_Segmented_Traits/blob/streamline/Files/Previoius_Measurements.xlsx): a file of measurements of minnow traits by  found in the supplemental information. See [Burress.md](Files/Burress.md) for more details.
 
 *Results*
 - a folder for the outputs from the workflow

--- a/Scripts/download-fish-air.sh
+++ b/Scripts/download-fish-air.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Download Fish-AIR data for family Cyprinidae and dataset GLIN
+set -e
+
+API_KEY=$1
+if [ -z "$API_KEY" ]
+then
+   echo "Error: Missing required Fish-AIR API key."
+   echo ""
+   echo "See https://fishair.org/ to create an API key."
+   echo "Usage: download-fish-air.sh <FISH-AIR-API-KEY>"
+   echo ""
+   exit 1
+fi
+
+DESTDIR=Files/Fish-AIR/Tulane
+
+# Make temp directory to hold the Fish-AIR files
+OUTDIR=$(mktemp -d)
+
+echo "Downloading dataset from Fish-AIR"
+curl -X 'GET' \
+  'https://fishair.org/api/multimedias/?family=Cyprinidae&dataset=GLIN&zipfile=true' \
+  -o $OUTDIR/fish-air.zip \
+  -H 'accept: application/json' \
+  -H "x-api-key: $API_KEY"
+
+echo "Extracting Fish-AIR zip file"
+unzip $OUTDIR/fish-air.zip -d $OUTDIR
+
+# Ensure destination directory exists
+mkdir -p $DESTDIR
+
+for FILENAME in meta.xml multimedia.csv imageQualityMetadata.csv citations.txt
+do
+    echo "Setting up $DESTDIR/$FILENAME"
+    FILEPATH=$(find $OUTDIR -name $FILENAME)
+    cp $FILEPATH $DESTDIR/$FILENAME
+done
+
+rm -rf $OUTDIR
+
+echo "Done"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,10 +1,12 @@
 # "Name:" becomes the object for the Snakefile
 
+# API key from fishair.org
+Fish_AIR_API_Key: ""
+
 # Input paths
-Image_DOI: doi:10.5072/FK2/GYHRV8
-File_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/meta.xml
-Image_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/multimedia.csv
-Image_Quality_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/imageQualityMetadata.csv
+File_Metadata: Files/Fish-AIR/Tulane/meta.xml
+Image_Metadata: Files/Fish-AIR/Tulane/multimedia.csv
+Image_Quality_Metadata: Files/Fish-AIR/Tulane/imageQualityMetadata.csv
 Burress: Files/Previous Fish Measurements - Burress et al. 2016.csv
 
 # Input settings

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,6 @@ File_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/meta.xml
 Image_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/multimedia.csv
 Image_Quality_Metadata: Files/Fish-AIR/Tulane/dtspz368c00q/imageQualityMetadata.csv
 Burress: Files/Previous Fish Measurements - Burress et al. 2016.csv
-Burress_DOI: doi:10.5072/FK2/KLN3CS
 
 # Input settings
 limit_images: 20 #if "" will run all, otherwise must input in integer

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -28,15 +28,6 @@ rule download_fish_air_data:
         DATAVERSE_CONTAINER
     shell: 'DATAVERSE_CONFIG_PATH={params.config} dva download {params.doi} Files/'
 
-rule download_burress:
-    output: config["Burress"]
-    params:
-        doi=config["Burress_DOI"],
-        config=DATAVERSE_CONFIG_PATH
-    container:
-        DATAVERSE_CONTAINER
-    shell: 'DATAVERSE_CONFIG_PATH={params.config} dva download {params.doi} Files/'
-
 rule dependencies:
     input: "dependencies.R"
     output: directory("Library")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -60,7 +60,7 @@ checkpoint select_minnow_images:
 # import BGNN_Snakemake rules used to create morpology presence.json files for images
 module segmentation:
     snakefile:
-        github("hdr-bgnn/BGNN_Core_Workflow", path="workflow/Snakefile", tag="1.0.0")
+        github("hdr-bgnn/BGNN_Core_Workflow", path="workflow/Snakefile", tag="1.0.1")
     # Use output from Minnow_Selection_Image_Quality_Metadata.R as input files
     config: { "list": config["Burress_Minnow_Filtered"] }
     # Store all files in a subdirectory

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -4,9 +4,6 @@ import pandas as pd
 configfile: "config/config.yaml"
     # names come from the config file
 
-DATAVERSE_CONFIG_PATH = os.path.expanduser('~/.dataverse')
-DATAVERSE_CONTAINER = 'docker://ghcr.io/imageomics/dataverse-access:1'
-
 rule all:
     input:
         presence_absence_matrix=config["Presence_Absence_Matrix"],
@@ -19,14 +16,13 @@ rule all:
 
 rule download_fish_air_data:
     output:
+        config["File_Metadata"],
         config["Image_Metadata"],
         config["Image_Quality_Metadata"]
     params:
-        doi=config["Image_DOI"],
-        config=DATAVERSE_CONFIG_PATH
-    container:
-        DATAVERSE_CONTAINER
-    shell: 'DATAVERSE_CONFIG_PATH={params.config} dva download {params.doi} Files/'
+        apikey=config["Fish_AIR_API_Key"],
+        script=srcdir("../Scripts/download-fish-air.sh")
+    shell: 'bash {params.script} {params.apikey}'
 
 rule dependencies:
     input: "dependencies.R"


### PR DESCRIPTION
Updates to the latest core workflow to use the latest containers.
Replaces dataverse download with directly using the Fish-AIR API and including the Burress file in the repo.
